### PR TITLE
Memoize results of parsing, normalization, and stringification

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ var assert = require('assert');
 var dict = require('./dict');
 var Parser = require('./parser');
 var Handlers = require('./handlers');
+var _ = require('underscore');
 
 var JSONPath = function() {
   this.initialize.apply(this, arguments);
@@ -9,6 +10,7 @@ var JSONPath = function() {
 
 JSONPath.prototype.initialize = function() {
   this.parser = new Parser();
+  this.parser.parse = _.memoize(this.parser.parse);
   this.handlers = new Handlers();
 };
 
@@ -152,7 +154,7 @@ JSONPath.prototype.nodes = function(obj, string, count) {
   return count ? matches.slice(0, count) : matches;
 };
 
-JSONPath.prototype.stringify = function(path) {
+JSONPath.prototype.stringify = _.memoize(function(path) {
 
   assert.ok(path, "we need a path");
 
@@ -187,9 +189,9 @@ JSONPath.prototype.stringify = function(path) {
   });
 
   return string;
-}
+});
 
-JSONPath.prototype._normalize = function(path) {
+JSONPath.prototype._normalize = _.memoize(function(path) {
 
   assert.ok(path, "we need a path");
 
@@ -234,7 +236,7 @@ JSONPath.prototype._normalize = function(path) {
   }
 
   throw new Error("couldn't understand path " + path);
-}
+});
 
 function _is_string(obj) {
   return Object.prototype.toString.call(obj) == '[object String]';


### PR DESCRIPTION
This is the approach taken in https://github.com/dchester/jsonpath/pull/75.

It does result in significant speedup, as the author suggests. It utilizes Underscore's `memoize` function: https://underscorejs.org/#memoize

This could result in memory issues if clients have a large number of dynamically generated JSON paths, but we currently have no such use cases. All our JSON paths are static. This affects caching only, not functionality, so it is covered by existing tests cases.

A better long-term approach might be to allow users of this library to pre-parse expressions and then pass them into functions that take the AST instead of string paths, but that's a bigger lift.